### PR TITLE
feat: fetch Amazon pricing and improve connectivity

### DIFF
--- a/phone-shopping-portal/js/app.js
+++ b/phone-shopping-portal/js/app.js
@@ -1,5 +1,6 @@
 // API Configuration
-const API_BASE_URL = 'http://localhost:8000/api/v1';
+// Determine API base automatically based on the current host
+const API_BASE_URL = `${window.location.protocol}//${window.location.hostname}:8000/api/v1`;
 
 // State Management
 const state = {

--- a/pis-service/README.md
+++ b/pis-service/README.md
@@ -45,6 +45,18 @@ pip install -r requirements.txt
 python seed_data.py
 ```
 
+The seeding script can optionally fetch live pricing from Amazon via the
+[Rainforest API](https://www.rainforestapi.com/). To enable this, set
+the following environment variables before running the script:
+
+```bash
+export AMAZON_API_KEY="your_rainforest_api_key"
+export AMAZON_API_DOMAIN="amazon.com"  # optional, defaults to amazon.com
+```
+
+If the variables are not set, the script will fall back to generated
+sample pricing data.
+
 ### 6. Run Server
 ```bash
 uvicorn app.main:app --reload --port 8000
@@ -100,6 +112,8 @@ MONGODB_URI=mongodb://localhost:27017
 DATABASE_NAME=pis_service
 PORT=8000
 ENV=development
+AMAZON_API_KEY=      # optional: API key for Amazon pricing (Rainforest API)
+AMAZON_API_DOMAIN=   # optional: Amazon domain (e.g. amazon.com)
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- use optional Rainforest API key to fetch Amazon prices during seeding
- compute API base URL from current host in portal
- document Amazon API usage and environment variables

## Testing
- `python -m py_compile pis-service/seed_data.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac9fdc66a08332a6caa713de35c491