### PR TITLE
feat: use rainforest api for richer amazon results

### DIFF
--- a/pis-service/README.md
+++ b/pis-service/README.md
@@ -106,10 +106,10 @@ AMAZON_API_DOMAIN=amazon.com      # Optional: Amazon domain
 ```
 
 ### Amazon API Integration
-To enable real-time pricing from Amazon:
+To enable real-time pricing and better model aggregation from Amazon:
 1. Get an API key from [Rainforest API](https://www.rainforestapi.com/)
 2. Add to `.env` file: `AMAZON_API_KEY=your_key_here`
-3. Run `make seed` to fetch fresh data with live prices
+3. Run `make seed` to fetch fresh data with live prices and improved product results
 
 ## 📊 Database Schema
 


### PR DESCRIPTION
## Summary
- use Rainforest API when an API key is provided to fetch Amazon search results with better model aggregation
- document Rainforest-based seeding in README

## Testing
- `make test` *(fails: Server is not running at http://localhost:8000)*

------
https://chatgpt.com/codex/tasks/task_e_68ad95bf06208332a2ae89d5520932ac